### PR TITLE
Protect against crashing when text columns might return NULL

### DIFF
--- a/gai++/src/DataStoreSqlite.cpp
+++ b/gai++/src/DataStoreSqlite.cpp
@@ -227,7 +227,10 @@ namespace GAI
             char* version = (char *)sqlite3_column_text( statement, 1 );
             char* url = (char *)sqlite3_column_text( statement, 2 );
             double timestamp = sqlite3_column_double( statement, 3 );
-            hits.push_back(createHit(version,url,timestamp));
+            if( version && url )
+            {
+                hits.push_back(createHit(version,url,timestamp));
+            }
         }
         
         // if appropriate, delete the hits


### PR DESCRIPTION
Should `sqlite3_column_text` ever return `NULL`, implicit conversion of `char*` into `std::string` will crash when `createHit` is invoked.

We will then ignore rows that have this problem, and drop them.