### PR TITLE
Fix incorrect Windows version in User-agent

### DIFF
--- a/gai++/gai.gyp
+++ b/gai++/gai.gyp
@@ -379,6 +379,7 @@
                     'gtestd.lib',
                     'ws2_32.lib',
                     'Rpcrt4.lib',
+		    'Mincore.lib',
                   ],
                 }, 
               },


### PR DESCRIPTION
OSVersion(...) function on Windows didn't work correctly in 64-bit builds.
It was returning non-deterministic values and causing Google Analytics
present the OS version as simply "Windows NT" without actual number.